### PR TITLE
Allow users to "await" the async requests.

### DIFF
--- a/Api2Pdf.DotNet.sln.DotSettings
+++ b/Api2Pdf.DotNet.sln.DotSettings
@@ -1,0 +1,4 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=libre/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=WKHTML/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=wkhtmltopdf/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/Api2Pdf.DotNet/Api2Pdf.DotNet.csproj
+++ b/Api2Pdf.DotNet/Api2Pdf.DotNet.csproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 
 </Project>

--- a/Api2Pdf.DotNet/Api2Pdf.cs
+++ b/Api2Pdf.DotNet/Api2Pdf.cs
@@ -70,6 +70,7 @@ namespace Api2PdfLibrary
             if (_httpClient == null)
             {
                 _httpClient = new HttpClient();
+                _httpClient.Timeout = new TimeSpan(0, 20, 0);
                 _httpClient.DefaultRequestHeaders.Add("Authorization", apiKey);
 
                 if(!string.IsNullOrWhiteSpace(tag))

--- a/Api2Pdf.DotNet/Api2Pdf.cs
+++ b/Api2Pdf.DotNet/Api2Pdf.cs
@@ -79,18 +79,12 @@ namespace Api2PdfLibrary
 
         public Api2PdfResponse Merge(IEnumerable<string> pdfUrls, bool inline = false, string outputFileName = null)
         {
-            var mergeRequest = new MergeRequest
-            {
-                Urls = pdfUrls.ToArray(),
-                FileName = outputFileName,
-                InlinePdf = inline
-            };
-
+            var mergeRequest = CreateMergeRequest(pdfUrls, inline, outputFileName);
 
             return _httpClient.PostPdfRequest<Api2PdfResponse>(API_MERGE_URL, mergeRequest);
         }
 
-        public Task<Api2PdfResponse> MergeAsync(IEnumerable<string> pdfUrls, bool inline = false, string outputFileName = null)
+        private static MergeRequest CreateMergeRequest(IEnumerable<string> pdfUrls, bool inline, string outputFileName)
         {
             var mergeRequest = new MergeRequest
             {
@@ -98,7 +92,12 @@ namespace Api2PdfLibrary
                 FileName = outputFileName,
                 InlinePdf = inline
             };
+            return mergeRequest;
+        }
 
+        public Task<Api2PdfResponse> MergeAsync(IEnumerable<string> pdfUrls, bool inline = false, string outputFileName = null)
+        {
+            var mergeRequest = CreateMergeRequest(pdfUrls, inline, outputFileName);
 
             return _httpClient.PostPdfRequestAsync<Api2PdfResponse>(API_MERGE_URL, mergeRequest);
         }

--- a/Api2Pdf.DotNet/Extensions.cs
+++ b/Api2Pdf.DotNet/Extensions.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 using System.Net.Http;
+using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 
@@ -18,12 +19,34 @@ namespace Api2PdfLibrary.Extensions
             return JsonConvert.DeserializeObject<T>(httpClient.PostAsync(url, content).Result.Content.ReadAsStringAsync().Result);
         }
 
+        public static async Task<T> PostPdfRequestAsync<T>(this HttpClient httpClient, string url, object obj)
+        {
+            var serializerSettings = new JsonSerializerSettings
+            {
+                ContractResolver = new CamelCasePropertyNamesContractResolver()
+            };
+
+            var content = new StringContent(JsonConvert.SerializeObject(obj, serializerSettings));
+            var response = await httpClient.PostAsync(url, content);
+            var responseContent = await response.Content.ReadAsStringAsync();
+            return JsonConvert.DeserializeObject<T>(responseContent);
+        }
+
+        
         public static T DeletePdfRequest<T>(this HttpClient httpClient, string url)
         {
             var serializerSettings = new JsonSerializerSettings();
             serializerSettings.ContractResolver = new CamelCasePropertyNamesContractResolver();
 
             return JsonConvert.DeserializeObject<T>(httpClient.DeleteAsync(url).Result.Content.ReadAsStringAsync().Result);
+        }
+        
+        public static async Task<T> DeletePdfRequestAsync<T>(this HttpClient httpClient, string url)
+        {
+            var response = await httpClient.DeleteAsync(url);
+            var responseContent = await response.Content.ReadAsStringAsync();
+
+            return JsonConvert.DeserializeObject<T>(responseContent);
         }
     }
 }


### PR DESCRIPTION
Hi There,

Under the hood I can see that asynchronous calls are being made over the network, however, it doesn't seem that users/clients can take full advantage of that as they are forced to call Synchronous code.
Would changes like these be useful to incorporate into your library?

We find this pattern particularly useful as we have a use case to generate a pdf per student in a class (usually 20-40 students) and running these requests in parallel significantly increases the responsiveness for the user.

Thanks,
Sean.